### PR TITLE
jfpanisset patch 5

### DIFF
--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -19,12 +19,12 @@ jobs:
           echo '#### nvidia-docker.list ####'
           cat /etc/apt/sources.list.d/nvidia-docker.list
           echo '### Get rid of cuda.list.save ###'
-          rm /etc/apt/sources.list.d/cuda.list.save
+          #sudo rm /etc/apt/sources.list.d/cuda.list.save
           #sudo apt-key del 7fa2af80
           #wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
           #sudo dpkg -i cuda-keyring_1.0-1_all.deb
-          sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-          time sudo apt-get update
-          sudo apt -y install libnpp-11-8
+          #sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+          #sudo apt-get update
+          #sudo apt -y install libnpp-11-8
           dpkg -l | grep -i nvidia
           ls -l /usr/lib/x86_64-linux-gnu/libnvoptix.so.*

--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -7,25 +7,37 @@ on:
 jobs:
   ubuntu-gpu:
     runs-on: ubuntu-20.04-gpu-6c-112g-336h-16vr
+    container:
+      image: aswf/ci-common:3
+      env:
+        - DISPLAY: $DISPLAY
+        - QT_X11_NO_MITSHM: 1
+      volumes:
+        - /tmp/.X11-unix:/tmp/.X11-unix
+      options: --gpus all
     steps:
-      - name: Update APT repo for CUDA
-        run: |
-          cat /etc/apt/sources.list
-          ls -l /etc/apt/sources.list.d/
-          echo '#### cuda.list ####'
-          cat /etc/apt/sources.list.d/cuda.list
-          echo '#### cuda.list.save ####'
-          cat /etc/apt/sources.list.d/cuda.list.save
-          echo '#### nvidia-docker.list ####'
-          cat /etc/apt/sources.list.d/nvidia-docker.list
-          echo '### Get rid of cuda.list.save ###'
-          #sudo rm /etc/apt/sources.list.d/cuda.list.save
-          #sudo apt-key del 7fa2af80
-          #wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
-          #sudo dpkg -i cuda-keyring_1.0-1_all.deb
-          #sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-          #sudo apt-get update
-          #sudo apt -y install libnpp-11-8
-          cat /proc/driver/nvidia/version
-          dpkg -l | grep -i nvidia
-          ls -l /usr/lib/x86_64-linux-gnu/libnvoptix.so.*
+       - name: run glxinfo inside container
+         run: |
+           nvidia-smi
+           glxinfo
+#      - name: Update APT repo for CUDA
+#        run: |
+#          cat /etc/apt/sources.list
+#          ls -l /etc/apt/sources.list.d/
+#          echo '#### cuda.list ####'
+#          cat /etc/apt/sources.list.d/cuda.list
+#          echo '#### cuda.list.save ####'
+#          cat /etc/apt/sources.list.d/cuda.list.save
+#          echo '#### nvidia-docker.list ####'
+#          cat /etc/apt/sources.list.d/nvidia-docker.list
+#          echo '### Get rid of cuda.list.save ###'
+#          #sudo rm /etc/apt/sources.list.d/cuda.list.save
+#          #sudo apt-key del 7fa2af80
+#          #wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+#          #sudo dpkg -i cuda-keyring_1.0-1_all.deb
+#          #sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+#          #sudo apt-get update
+#          #sudo apt -y install libnpp-11-8
+#          cat /proc/driver/nvidia/version
+#          dpkg -l | grep -i nvidia
+#          ls -l /usr/lib/x86_64-linux-gnu/libnvoptix.so.*

--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -6,20 +6,21 @@ on:
   pull_request:
 jobs:
   ubuntu-gpu:
-    runs-on: ubuntu-20.04-gpu-6c-112g-336h-16vr
-    container:
-      image: aswf/ci-common:3-clang15
-      env:
-        DISPLAY: $DISPLAY
-        QT_X11_NO_MITSHM: 1
-      volumes:
-        - /tmp/.X11-unix:/tmp/.X11-unix
-      options: --gpus all
+#    runs-on: ubuntu-20.04-gpu-6c-112g-336h-16vr
+    runs-on: ubuntu-20.04-gpu-12c-224g-672h-32vr
+#    container:
+#      image: aswf/ci-common:3-clang15
+#      env:
+#        DISPLAY: $DISPLAY
+#        QT_X11_NO_MITSHM: 1
+#      volumes:
+#        - /tmp/.X11-unix:/tmp/.X11-unix
+#      options: --gpus all
     steps:
        - name: run glxinfo inside container
          run: |
            nvidia-smi
-           glxinfo
+#           glxinfo
 #      - name: Update APT repo for CUDA
 #        run: |
 #          cat /etc/apt/sources.list

--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -6,9 +6,9 @@ on:
   pull_request:
 jobs:
   ubuntu-gpu:
-    runs-on: ubuntu-22.04-gpu-6c-112g-336h-16vr
+    runs-on: ubuntu-20.04-gpu-6c-112g-336h-16vr
     container:
-      image: aswf/ci-common:3
+      image: aswf/ci-common:3-clang15
       env:
         DISPLAY: $DISPLAY
         QT_X11_NO_MITSHM: 1

--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   ubuntu-gpu:
-    runs-on: ubuntu-20.04-gpu-6c-112g-336h-16vr
+    runs-on: ubuntu-22.04-gpu-6c-112g-336h-16vr
     container:
       image: aswf/ci-common:3
       env:

--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
 jobs:
   ubuntu-gpu:
-#    runs-on: ubuntu-20.04-gpu-6c-112g-336h-16vr
-    runs-on: ubuntu-20.04-gpu-12c-224g-672h-32vr
+    runs-on: ubuntu-20.04-gpu-6c-112g-336h-16vr
+#    runs-on: ubuntu-20.04-gpu-12c-224g-672h-32vr
 #    container:
 #      image: aswf/ci-common:3-clang15
 #      env:

--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -26,5 +26,6 @@ jobs:
           #sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
           #sudo apt-get update
           #sudo apt -y install libnpp-11-8
+          cat /proc/driver/nvidia/version
           dpkg -l | grep -i nvidia
           ls -l /usr/lib/x86_64-linux-gnu/libnvoptix.so.*

--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -10,8 +10,8 @@ jobs:
     container:
       image: aswf/ci-common:3
       env:
-        - DISPLAY: $DISPLAY
-        - QT_X11_NO_MITSHM: 1
+        DISPLAY: $DISPLAY
+        QT_X11_NO_MITSHM: 1
       volumes:
         - /tmp/.X11-unix:/tmp/.X11-unix
       options: --gpus all

--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -26,3 +26,5 @@ jobs:
           sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
           time sudo apt-get update
           sudo apt -y install libnpp-11-8
+          dpkg -l | grep -i nvidia
+          ls -l /usr/lib/x86_64-linux-gnu/libnvoptix.so.*


### PR DESCRIPTION
- Create gpu_test.yml
- Update gpu_test.yml
- Update gpu_test.yml
- Update gpu_test.yml
- Update gpu_test.yml
- Check for Optix install
- Only look at what we need
- Print out driver version
- What GPU do we have?
- multi env var syntax
- Are GPU runners now running Ubuntu 22.04?
- Ubuntu 22.04 is correct, use the right container
- Try larger instance, no container
- Return gpu_test workflow runner to 16vr
